### PR TITLE
game manager - pause/unpause

### DIFF
--- a/GameManager.gd
+++ b/GameManager.gd
@@ -1,0 +1,26 @@
+extends Node
+
+# can access when the game is paused from any script using this signal
+signal game_paused(is_paused: bool)
+
+var gm_dtag := "GAME MANAGER: "
+# setter that, when anything changes is_paused, sets the new value to either 
+# true or false, then pauses the whole tree, then emits the signal.
+var is_paused: bool = false:
+    set(value):
+        is_paused = value
+        get_tree().paused = value
+        game_paused.emit(value)
+
+# makes sure this script runs even when game is paused. 
+# NOTE: i thought autoloads are always on, but i guess not? confuse
+func _ready():
+    process_mode = Node.PROCESS_MODE_ALWAYS
+    is_paused = false
+
+# assigns pause to a key
+func _unhandled_input(event):
+    if event.is_action_pressed("pause"):
+        print(gm_dtag, "Debug key pressed! Current pause state: ", is_paused)
+        is_paused = !is_paused
+        print(gm_dtag, "Game is now: ", "paused" if is_paused else "unpaused")

--- a/Global.gd
+++ b/Global.gd
@@ -106,11 +106,7 @@ func _ready():
     }
     
 func _physics_process(delta: float) -> void:
-    
+          
     # defining wizard global position and grid coordinates
     wizard_position = wizard.global_position
     wizard_cell_position = round(wizard_position / tile_size)
-    
-    #check to see if wizard position is updating
-    #print(wizard_position)
-    #print(wizard_cell_position)

--- a/enemy_pumpkin.gd
+++ b/enemy_pumpkin.gd
@@ -12,6 +12,7 @@ extends CharacterBody2D
 
 var new_health: int = 0
 var projectile_count: int = 0
+var pump_dtag := "PUMPKIN: "
 
 func _ready():
     # TODO: Set initial start position
@@ -33,19 +34,19 @@ func _on_enemy_pumpkin_collision_detector_area_entered(area: Area2D) -> void:
     if area.is_in_group("Projectiles"):
         
         # DEBUG
-        print("pumpkin hit by: ", area)
-        print("pumpkin health before hit: ", health)
-        print("pumpkin new_health before hit: ", new_health)
+        print(pump_dtag, "pumpkin hit by: ", area)
+        print(pump_dtag, "pumpkin health before hit: ", health)
+        print(pump_dtag, "pumpkin new_health before hit: ", new_health)
         
         new_health = health - area.projectile_damage
         
         # DEBUG
-        print("pumpkin new_health after hit: ", new_health)
+        print(pump_dtag, "pumpkin new_health after hit: ", new_health)
         
         health = new_health
         
         #DEBUG
-        print("health after all the calculations: ", health)
+        print(pump_dtag, "health after all the calculations: ", health)
         
         # kill the enemy
         if health <= 0:

--- a/main.gd
+++ b/main.gd
@@ -1,6 +1,14 @@
 extends Node2D
 
+var m_tag := "MAIN: "
+
 func _ready():
     pass
+ 
+# debugging from main node   
+func _unhandled_input(event: InputEvent) -> void:
     
-    
+    # get readable scene tree (not when game is paused tho)
+    if event.is_action_pressed("debug"):
+        var tree = get_tree_string_pretty()
+        print(tree)

--- a/project.godot
+++ b/project.godot
@@ -20,6 +20,7 @@ config/icon="res://icon.svg"
 Global="*res://Global.gd"
 Tilling="*res://Tilling.gd"
 PickPlace="*res://pick_place.gd"
+GameManager="*res://GameManager.gd"
 CombatManager="res://CombatManager.gd"
 
 [debug]
@@ -82,6 +83,11 @@ shoot={
 debug={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
+]
+}
+pause={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":96,"key_label":0,"unicode":96,"location":0,"echo":false,"script":null)
 ]
 }
 


### PR DESCRIPTION
added a global game manager script that can pause and unpause the game, with process mode set to always. also added some more debug framework, as well as prepped game manager script for future content. 